### PR TITLE
fix: add mitigation for log4shell - CVE-2021-44228

### DIFF
--- a/8/debian-10/rootfs/opt/bitnami/scripts/solr/postunpack.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/solr/postunpack.sh
@@ -26,4 +26,4 @@ done
 replace_in_file "$SOLR_BIN_DIR"/solr.in.sh "#SOLR_JAVA_HOME=\"\"" "SOLR_JAVA_HOME=$SOLR_JAVA_HOME"
 replace_in_file "$SOLR_BIN_DIR"/solr.in.sh "#SOLR_PID_DIR=" "SOLR_PID_DIR=$SOLR_PID_DIR"
 replace_in_file "$SOLR_BIN_DIR"/solr.in.sh "#SOLR_LOGS_DIR=logs" "SOLR_LOGS_DIR=$SOLR_LOGS_DIR"
-
+echo "SOLR_OPTS=\"\$SOLR_OPTS -Dlog4j2.formatMsgNoLookups=true\"" >> "$SOLR_BIN_DIR"/solr.in.sh


### PR DESCRIPTION
add mitigation for log4shell RCE

https://github.com/bitnami/bitnami-docker-solr/issues/41